### PR TITLE
Implement model after changes tracking

### DIFF
--- a/lib/paper_trail/events/base.rb
+++ b/lib/paper_trail/events/base.rb
@@ -239,9 +239,17 @@ module PaperTrail
       #
       # @api private
       def object_attrs_for_paper_trail(is_touch)
-        attrs = nonskipped_attributes_before_change(is_touch)
+        attrs = if @record.class.paper_trail_options[:model_after]
+                  nonskipped_attributes_after_change(is_touch)
+                else
+                  nonskipped_attributes_before_change(is_touch)
+                end
         AttributeSerializers::ObjectAttribute.new(@record.class).serialize(attrs)
         attrs
+      end
+
+      def nonskipped_attributes_after_change(_is_touch)
+        @record.attributes.except(*@record.paper_trail_options[:skip])
       end
 
       # @api private

--- a/lib/paper_trail/events/create.rb
+++ b/lib/paper_trail/events/create.rb
@@ -24,6 +24,10 @@ module PaperTrail
           changes = notable_changes
           data[:object_changes] = prepare_object_changes(changes)
         end
+        # assign the created object to data hash
+        if @record.class.paper_trail_options[:model_after]
+          data[:object] = recordable_object(false)
+        end
         merge_item_subtype_into(data)
         merge_metadata_into(data)
       end

--- a/spec/dummy_app/app/models/on/after_create.rb
+++ b/spec/dummy_app/app/models/on/after_create.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module On
+  class AfterCreate < ActiveRecord::Base
+    self.table_name = :on_create
+    has_paper_trail on: [:create], model_after: true
+  end
+end

--- a/spec/dummy_app/app/models/on/after_update.rb
+++ b/spec/dummy_app/app/models/on/after_update.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module On
+  class AfterUpdate < ActiveRecord::Base
+    self.table_name = :on_update
+    has_paper_trail on: [:update], model_after: true
+  end
+end

--- a/spec/models/on/after_create_spec.rb
+++ b/spec/models/on/after_create_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_dependency "on/after_create"
+
+module On
+  RSpec.describe AfterCreate, type: :model, versioning: true do
+    describe "#versions" do
+      it "only have a version for the create event" do
+        record = described_class.create(name: "Alice")
+        record.update(name: "blah")
+        record.destroy
+        expect(record.versions.length).to(eq(1))
+        expect(record.versions.last.event).to(eq("create"))
+      end
+    end
+
+    context "#paper_trail_event" do
+      it "rembembers the custom event name" do
+        record = described_class.new
+        record.paper_trail_event = "banana"
+        record.update(name: "blah")
+        record.destroy
+        expect(record.versions.length).to(eq(1))
+        expect(record.versions.last.event).to(eq("banana"))
+      end
+
+      context 'track changes on model after' do
+        it "store the after changed record in object" do
+          record = described_class.new
+          record.update(name: "blah")
+          record.destroy
+          expect(record.versions.last.reify.name).to(eq('blah'))
+        end
+      end
+    end
+
+    describe "#touch" do
+      it "does not create a version" do
+        record = described_class.create(name: "Alice")
+        expect { record.touch }.not_to(
+          change { record.versions.count }
+        )
+      end
+    end
+  end
+end

--- a/spec/models/on/after_update_spec.rb
+++ b/spec/models/on/after_update_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_dependency "on/after_update"
+
+module On
+  RSpec.describe AfterUpdate, type: :model, versioning: true do
+    describe "#versions" do
+      it "only creates one version record, for the update event" do
+        record = described_class.create(name: "Alice")
+        record.update(name: "blah")
+        record.destroy
+        expect(record.versions.length).to(eq(1))
+        expect(record.versions.last.event).to(eq("update"))
+      end
+    end
+
+    context "#paper_trail_event" do
+      it "rembembers the custom event name" do
+        record = described_class.create(name: "Alice")
+        record.paper_trail_event = "banana"
+        record.update(name: "blah")
+        record.destroy
+        expect(record.versions.length).to(eq(1))
+        expect(record.versions.last.event).to(eq("banana"))
+      end
+
+      context 'store the after changed record in object' do
+        it 'store the after changed record in object' do
+          record = described_class.create(name: "Alice")
+          record.update(name: "blah")
+          record.update(name: "blah blah")
+          record.destroy
+          expect(record.versions.last.reify.name).to(eq("blah blah"))
+        end
+      end
+    end
+
+    describe "#touch" do
+      it "does not create a version" do
+        record = described_class.create(name: "Alice")
+        expect { record.touch }.not_to(
+          change { record.versions.count }
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently papertrail is using model before to track changes which means if a record changed from version A to version B, it will papertrail the record attributes of version A.

This PR added an optional arguments to the AR macro to allow model after papertrailing, which means with the above scenario, version B will be papertrailed instead of version A.